### PR TITLE
Adds the lobster suit to the autodrobe

### DIFF
--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -47,7 +47,9 @@
 					/obj/item/clothing/suit/toggle/owlwings/griffinwings = 1,
 					/obj/item/clothing/under/griffin = 1,
 					/obj/item/clothing/shoes/griffin = 1,
-					/obj/item/clothing/head/griffin = 1,
+					/obj/item/clothing/head/griffin = 1,3
+					/obj/item/clothing/head/lobsterhat = 1,
+					/obj/item/clothing/under/lobster = 1,
 					/obj/item/clothing/suit/apron = 1,
 					/obj/item/clothing/under/waiter = 1,
 					/obj/item/clothing/suit/jacket/miljacket = 1,
@@ -210,7 +212,6 @@
 		           /obj/item/skub = 1,
 		           /obj/item/clothing/under/lampskirt = 1,
 		           /obj/item/clothing/under/yogs/soviet_dress_uniform = 1, //yogs start
-		           /obj/item/clothing/under/yogs/enclaveo = 1,
 		           /obj/item/clothing/under/yogs/rycliesuni = 1,
 		           /obj/item/clothing/head/yogs/toad = 1,
 		           /obj/item/clothing/head/helmet/justice = 1,


### PR DESCRIPTION
Havent tested it

# Wiki Documentation

Add the lobster suit to the list of buyable items in the autodrobe
# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: lobster in autodrobe
/:cl:

![image](https://user-images.githubusercontent.com/68789204/135944836-814e1413-f7fa-4b07-8d27-bef1075e4b5a.png)
